### PR TITLE
tls line causes 404 error

### DIFF
--- a/kubernetes/traefik-cert-manager/traefik/dashboard/ingress.yaml
+++ b/kubernetes/traefik-cert-manager/traefik/dashboard/ingress.yaml
@@ -17,5 +17,5 @@ spec:
       services:
         - name: api@internal
           kind: TraefikService
-  tls:
-    secretName: local-example-com-staging-tls
+#  tls:
+#    secretName: local-example-com-staging-tls


### PR DESCRIPTION
Found that the tls line is causing an error if not commented out. Saw in your video you had that commented out in your local clone. May help with those who clone an work in the directory locally as well.

-Cheers!