### PR TITLE
Allow external name services through traefik

### DIFF
--- a/kubernetes/traefik-cert-manager/traefik/values.yaml
+++ b/kubernetes/traefik-cert-manager/traefik/values.yaml
@@ -29,8 +29,10 @@ providers:
   kubernetesCRD:
     enabled: true
     ingressClass: traefik-external
+    allowExternalNameServices: true
   kubernetesIngress:
     enabled: true
+    allowExternalNameServices: true
     publishedService:
       enabled: false
 


### PR DESCRIPTION
I feel like one of the next steps someone is going to take after going through your tutorials and configuring Traefik and Cert-manager is that they are going to want to use those kubernetes services from their cluster to apply certificates and ingresses to other services in their home. Like their hypervisor login page, or router, or local website, etc. By default, Traefik does not allow this. This addition will allow Traefik to accept services that point to resources that are not in the kubernetes cluster itself.  This will save a lot of headache when someone sets up a service and ingress to their external service and try to figure out why it doesn't work. 

See this issue/discussion #18 