### PR TITLE
Fixing "letsencrypt-staging" not found error

### DIFF
--- a/kubernetes/traefik-cert-manager/cert-manager/values.yaml
+++ b/kubernetes/traefik-cert-manager/cert-manager/values.yaml
@@ -6,5 +6,5 @@ extraArgs:
 podDnsPolicy: None
 podDnsConfig:
   nameservers:
-    - "1.1.1.1"
-    - "9.9.9.9"
+    - 1.1.1.1
+    - 9.9.9.9


### PR DESCRIPTION
Removed the **double quotes** that were around the name servers' IP addresses. 

This fixes the following error:  `Referenced "ClusterIssuer" not found: clusterissuer.cert-manager.io "letsencrypt-staging" not found`. 

It is in line with the file format as in https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config.