### PR TITLE
Replaced pihole add prefix middleware with a redirectRegex middleware

### DIFF
--- a/docker/traefik/data/config.yml
+++ b/docker/traefik/data/config.yml
@@ -151,9 +151,10 @@ http:
         passHostHeader: true
 #endregion
   middlewares:
-    addprefix-pihole:
-      addPrefix:
-        prefix: "/admin"
+    pihole-redirect:
+      redirectRegex:
+        regex: "^https?://pihole.local.example.com/$"
+        replacement: "https://pihole.local.example.com/admin/"
     https-redirect:
       redirectScheme:
         scheme: https


### PR DESCRIPTION
addPrefix middleware allowed the login screen to load but would just go to a white screen after login.

redirecting via regex works around this problem and allows the web interface to be used through the proxy.