### PR TITLE
fix: update pihole middleware name

### DIFF
--- a/docker/traefik/data/config.yml
+++ b/docker/traefik/data/config.yml
@@ -15,7 +15,7 @@ http:
       rule: "Host(`pihole.local.example.com`)"
       middlewares:
         - default-headers
-        - addprefix-pihole
+        - pihole-redirect
       tls: {}
       service: pihole
     homebridge:


### PR DESCRIPTION
# fix: update pihole middleware name

While using this as a template for setting up traefik locally on my home server, I noticed that while using pihole, the middleware name was incorrect and caused an error.

I see this was changed in #38 to `pihole-redirect` instead of `addprefix-pihole` in the `middleware` section, but seems that updating it here was missed.