### PR TITLE
Update Traefik ports.web.redirectTo spec

### DIFF
--- a/kubernetes/traefik-cert-manager/traefik/values.yaml
+++ b/kubernetes/traefik-cert-manager/traefik/values.yaml
@@ -16,7 +16,9 @@ deployment:
 
 ports:
   web:
-    redirectTo: websecure
+    redirectTo:
+      port: websecure
+      priority: 10
   websecure:
     tls:
       enabled: true


### PR DESCRIPTION
Following https://www.youtube.com/watch?v=G4CmbYL9UPg - Helm installations for the `traefik-cert-manager` directory are currently throwing errors:

```bash
$ helm install -n traefik traefik traefik/traefik --values=values.yaml
Error: INSTALLATION FAILED: execution error at (traefik/templates/_podtemplate.tpl:567:19): ERROR: Syntax of `ports.web.redirectTo` has changed to `ports.web.redirectTo.port`. Details in PR #934.
```

https://github.com/traefik/traefik-helm-chart/pull/934 extends the spec with a new `priority` attribute - updating the implementation here makes for a successful installation!

```sh
$ helm install -n traefik traefik traefik/traefik --values=values.yaml
NAME: traefik
LAST DEPLOYED: Sun Nov 12 19:16:37 2023
NAMESPACE: traefik
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Traefik Proxy v2.10.5 has been deployed successfully on traefik namespace !
```

Thank you for all of this great learning material 😄 