### PR TITLE
#49 Docker image called out for Guacamole is deprecated

### DIFF
--- a/docker/guacamole/README.md
+++ b/docker/guacamole/README.md
@@ -3,3 +3,5 @@
 Documentation [here](https://docs.technotim.live/posts/guacamole-remote-access-gateway/)
 
 Video [here](https://www.youtube.com/watch?v=LWdxhZyHT_8)
+
+Docker hub documentation [here](https://hub.docker.com/r/flcontainers/guacamole)

--- a/docker/guacamole/docker-compose.yml
+++ b/docker/guacamole/docker-compose.yml
@@ -1,10 +1,13 @@
 version: "3.1"
 services:
   guacamole:
-    image: maxwaldorf/guacamole #oznum is deprecated
+    image: flcontainers/guacamole
     container_name: guacamole
+    environment:
+      TZ: 'UTC'
     volumes:
       - postgres:/config
+      - /etc/localtime:/etc/localtime:ro
     ports:
       - 8080:8080
 volumes:


### PR DESCRIPTION
Hi @timothystewart6 

I create a PR that contains changes for Guacamole:

- changed docker image to: flcontainers/guacamole
- added `TZ` environment
- bind `localtime` from host to container
- added URL to new docker image in README

Resolves #49

This image `flcontainers/guacamole` is suggested by `maxwaldorf/guacamole`.