### PR TITLE
fix(Certmanager-Traefik): Updated deprecated 'redirectTo' to 'redirections' in values.yaml per traefik helm chart v34.0.0 requirements 

### DIFF
--- a/kubernetes/traefik-cert-manager/traefik/values.yaml
+++ b/kubernetes/traefik-cert-manager/traefik/values.yaml
@@ -16,9 +16,10 @@ deployment:
 
 ports:
   web:
-    redirectTo:
-      port: websecure
-      priority: 10
+    redirections:
+      entrypoint:
+        to: websecure
+        priority: 10
   websecure:
     http3:
       enabled: true


### PR DESCRIPTION
Hey @timothystewart6 ! Long time viewer. 

I was going through the [Wildcard Certificates with Traefik + cert-manager + Let's Encrypt in Kubernetes Tutorial ](https://www.youtube.com/watch?v=G4CmbYL9UPg) and ran into this error when installing `traefik`:

```
helm install --namespace=traefik traefik traefik/traefik --values=values.yaml
Error: INSTALLATION FAILED: execution error at (traefik/templates/_podtemplate.tpl:601:18): ERROR: redirectTo syntax has been removed in v34 of this Chart. See Release notes or EXAMPLES.md for new syntax.
```

It turns out the `redirectTo` has been moved to `redirections`. 
[See release notes for version v34.0.0](https://github.com/traefik/traefik-helm-chart/releases/tag/v34.0.0) and [PR #1301 from traefik/traefik-helm-chart](https://github.com/traefik/traefik-helm-chart/pull/1301)

I thought that I'd make the change for the next person. 

Thanks! 