### PR TITLE
feat: add authentik docker compose starter

### DIFF
--- a/docker/authentik/README.md
+++ b/docker/authentik/README.md
@@ -1,0 +1,5 @@
+# authentik
+
+Documentation [here](https://docs.goauthentik.io/)
+
+Video [here](https://www.youtube.com/watch?v=N5unsATNpJk)

--- a/docker/authentik/docker-compose.yml
+++ b/docker/authentik/docker-compose.yml
@@ -1,0 +1,91 @@
+version: '3.4'
+
+services:
+  postgresql:
+    image: docker.io/library/postgres:16-alpine
+    container_name: authentik_postgres
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}']
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=${PG_PASS}
+      - POSTGRES_USER=${PG_USER:-authentik}
+      - POSTGRES_DB=${PG_DB:-authentik}
+
+  redis:
+    image: docker.io/library/redis:alpine
+    container_name: authentik_redis
+    command: --save 60 1 --loglevel warning
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep PONG']
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 3s
+    volumes:
+      - ./redis:/data
+
+  server:
+    image: ghcr.io/goauthentik/server:2024.12.3
+    container_name: authentik_server
+    restart: unless-stopped
+    command: server
+    environment:
+      - AUTHENTIK_REDIS__HOST=redis
+      - AUTHENTIK_POSTGRESQL__HOST=postgresql
+      - AUTHENTIK_POSTGRESQL__USER=${PG_USER:-authentik}
+      - AUTHENTIK_POSTGRESQL__NAME=${PG_DB:-authentik}
+      - AUTHENTIK_POSTGRESQL__PASSWORD=${PG_PASS}
+      - AUTHENTIK_SECRET_KEY=${AUTHENTIK_SECRET_KEY}
+      - AUTHENTIK_ERROR_REPORTING__ENABLED=false
+    volumes:
+      - ./media:/media
+      - ./custom-templates:/templates
+    networks:
+      - proxy
+      - default
+    ports:
+      - '${AUTHENTIK_PORT_HTTP:-9000}:9000'
+      - '${AUTHENTIK_PORT_HTTPS:-9443}:9443'
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.authentik.rule=Host(`auth.local.example.com`)'
+      - 'traefik.http.routers.authentik.entrypoints=https'
+      - 'traefik.http.routers.authentik.tls=true'
+      - 'traefik.http.services.authentik.loadbalancer.server.port=9000'
+    depends_on:
+      - postgresql
+      - redis
+
+  worker:
+    image: ghcr.io/goauthentik/server:2024.12.3
+    container_name: authentik_worker
+    restart: unless-stopped
+    command: worker
+    environment:
+      - AUTHENTIK_REDIS__HOST=redis
+      - AUTHENTIK_POSTGRESQL__HOST=postgresql
+      - AUTHENTIK_POSTGRESQL__USER=${PG_USER:-authentik}
+      - AUTHENTIK_POSTGRESQL__NAME=${PG_DB:-authentik}
+      - AUTHENTIK_POSTGRESQL__PASSWORD=${PG_PASS}
+      - AUTHENTIK_SECRET_KEY=${AUTHENTIK_SECRET_KEY}
+      - AUTHENTIK_ERROR_REPORTING__ENABLED=false
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./media:/media
+      - ./certs:/certs
+      - ./custom-templates:/templates
+    depends_on:
+      - postgresql
+      - redis
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
Adds a docker-compose quick starter for [authentik](https://goauthentik.io/), an open-source Identity Provider that integrates well with Traefik as a forward auth provider.

The setup includes:
- PostgreSQL 16 (alpine) as the database backend
- Redis for caching and task queuing
- authentik server with Traefik labels
- authentik worker for background tasks

Follows the same pattern as the existing `authelia` starter. Users running Traefik who want a more feature-rich SSO/IdP alternative will find this useful.